### PR TITLE
add generating release notes to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,24 @@ jobs:
         run: |-
           echo "NEW_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
 
+      - name: 'Get previous release tag'
+        uses: 'actions/github-script@v6'
+        with:
+          script: |-
+            try {
+              const latestRelease = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              core.exportVariable("PREV_TAG", latestRelease.data.tag_name);
+            } catch (err) {
+              if (err["status"] === 404) {
+                core.info(`No releases found`);
+              } else {
+                core.setFailed(`Failed to load latest release: ${err}`);
+              }
+            }
+
       - name: 'Create release'
         uses: 'actions/github-script@v6'
         with:
@@ -29,6 +47,19 @@ jobs:
                 name: tag,
                 generate_release_notes: true,
               };
+
+              if (process.env.PREV_TAG) {
+                const releaseNotes = await github.rest.repos.generateReleaseNotes({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_name: tag,
+                  target_commitish: context.sha,
+                  previous_tag_name: process.env.PREV_TAG,
+                });
+                
+                createReleaseRequest.body = releaseNotes.data.body;
+                createReleaseRequest.generate_release_notes = false;
+              }
 
               const response = await github.rest.repos.createRelease(createReleaseRequest);
 


### PR DESCRIPTION
Removed this to streamline process, but causes issues with generated DIFF url in release notes. We have to explicitly find the previous tag.