### PR TITLE
Deploy centralized organization stale bot

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,9 +15,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - name: 'Run actionlint with reviewdog'
-      uses: reviewdog/action-actionlint@v1.72.0
-      with:
-        fail_on_error: true
-        reporter: 'github-pr-check'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - name: 'Run actionlint with reviewdog'
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # ratchet:reviewdog/action-actionlint@v1.72.0
+        with:
+          fail_on_error: true
+          reporter: 'github-pr-check'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: actionlint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: 'Run actionlint with reviewdog'
-      uses: reviewdog/action-actionlint@v1.7.2
+      uses: reviewdog/action-actionlint@v1.72.0
       with:
         fail_on_error: true
         reporter: 'github-pr-check'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,20 +4,20 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: 'read'
+  pull-requests: 'write'
 
 concurrency:
-  group: actionlint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: 'actionlint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: 'true'
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # ratchet:actions/checkout@v6
       - name: 'Run actionlint with reviewdog'
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # ratchet:reviewdog/action-actionlint@v1.72.0
+        uses: 'reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d' # ratchet:reviewdog/action-actionlint@v1.72.0
         with:
           fail_on_error: true
           reporter: 'github-pr-check'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,19 @@
+name: 'Actionlint'
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: 'Run actionlint with reviewdog'
+      uses: reviewdog/action-actionlint@v1.7.2
+      with:
+        fail_on_error: true
+        reporter: 'github-pr-check'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: 'Run actionlint with reviewdog'
         uses: 'reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d' # ratchet:reviewdog/action-actionlint@v1.72.0
         with:
-          fail_on_error: true
+          fail_level: 'error'
           reporter: 'github-pr-check'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: 'actionlint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
-  cancel-in-progress: 'true'
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: 'Run actionlint with reviewdog'
       uses: reviewdog/action-actionlint@v1.7.2
       with:

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -1,9 +1,9 @@
 name: 'Centralized Organization Stale Bot'
-
+permissions: {}
 on:
   schedule:
-  # Run daily at 01:00 UTC
-  - cron: '0 1 * * *'
+    # Run daily at 01:00 UTC
+    - cron: '0 1 * * *'
   workflow_dispatch:
 
 jobs:
@@ -13,38 +13,38 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.repos }}
     steps:
-    - id: 'auth-minty'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
-      with:
-        create_credentials_file: false
-        export_environment_variables: false
-        workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
-        service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
-        token_format: 'id_token'
-        id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
-        id_token_include_email: true
+      - id: 'auth-minty'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+        with:
+          create_credentials_file: false
+          export_environment_variables: false
+          workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+          service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+          token_format: 'id_token'
+          id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          id_token_include_email: true
 
-    - id: 'mint-github-token'
-      uses: 'abcxyz/github-token-minter/.github/actions/minty@45c29ca3418ff3bb3ad5815d88a80536efeba21b' # ratchet:abcxyz/github-token-minter/.github/actions/minty@main
-      with:
-        id_token: '${{ steps.auth-minty.outputs.id_token }}'
-        service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
-        requested_permissions: |-
-          {
-            "scope": "stale-bot",
-            "repositories": ["*"],
-            "org_name": "google-github-actions"
-          }
+      - id: 'mint-github-token'
+        uses: 'abcxyz/github-token-minter/.github/actions/minty@45c29ca3418ff3bb3ad5815d88a80536efeba21b' # ratchet:abcxyz/github-token-minter/.github/actions/minty@main
+        with:
+          id_token: '${{ steps.auth-minty.outputs.id_token }}'
+          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+          requested_permissions: |-
+            {
+              "scope": "stale-bot",
+              "repositories": ["*"],
+              "org_name": "google-github-actions"
+            }
 
-    - name: 'List active repositories'
-      id: set-matrix
-      env:
-        GH_TOKEN: ${{ steps.mint-github-token.outputs.token }}
-      run: |
-        # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
-        REPOS=$(gh api --paginate /orgs/google-github-actions/repos -q '[.[] | select(.archived == false and .private == false and .fork == false) | .name]' | jq -c .)
-        echo "repos=${REPOS}" >> $GITHUB_OUTPUT
+      - name: 'List active repositories'
+        id: set-matrix
+        env:
+          GH_TOKEN: ${{ steps.mint-github-token.outputs.token }}
+        run: |
+          # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
+          REPOS=$(gh api --paginate /orgs/google-github-actions/repos -q '[.[] | select(.archived == false and .private == false and .fork == false) | .name]' | jq -c .)
+          echo "repos=${REPOS}" >> $GITHUB_OUTPUT
 
   # Stage 2: Fan out official actions/stale across all discovered repositories
   apply-stale-rules:
@@ -56,46 +56,46 @@ jobs:
         repo: ${{ fromJson(needs.fetch-repositories.outputs.matrix) }}
 
     steps:
-    - id: 'auth-minty'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
-      with:
-        create_credentials_file: false
-        export_environment_variables: false
-        workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
-        service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
-        token_format: 'id_token'
-        id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
-        id_token_include_email: true
+      - id: 'auth-minty'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+        with:
+          create_credentials_file: false
+          export_environment_variables: false
+          workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+          service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+          token_format: 'id_token'
+          id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          id_token_include_email: true
 
-    - id: 'mint-github-token'
-      uses: 'abcxyz/github-token-minter/.github/actions/minty@45c29ca3418ff3bb3ad5815d88a80536efeba21b' # ratchet:abcxyz/github-token-minter/.github/actions/minty@main
-      with:
-        id_token: '${{ steps.auth-minty.outputs.id_token }}'
-        service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
-        requested_permissions: |-
-          {
-            "scope": "stale-bot",
-            "repositories": ["${{ matrix.repo }}"],
-            "org_name": "google-github-actions"
-          }
+      - id: 'mint-github-token'
+        uses: 'abcxyz/github-token-minter/.github/actions/minty@45c29ca3418ff3bb3ad5815d88a80536efeba21b' # ratchet:abcxyz/github-token-minter/.github/actions/minty@main
+        with:
+          id_token: '${{ steps.auth-minty.outputs.id_token }}'
+          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+          requested_permissions: |-
+            {
+              "scope": "stale-bot",
+              "repositories": ["${{ matrix.repo }}"],
+              "org_name": "google-github-actions"
+            }
 
-    - name: 'Run official stale bot'
-      uses: actions/stale@v10.2.0
-      env:
-        GITHUB_REPOSITORY: 'google-github-actions/${{ matrix.repo }}'
-      with:
-        repo-token: ${{ steps.mint-github-token.outputs.token }}
-        operations-per-run: 300 # Increased burndown limit for first execution
+      - name: 'Run official stale bot'
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # ratchet:actions/stale@v10.2.0
+        env:
+          GITHUB_REPOSITORY: 'google-github-actions/${{ matrix.repo }}'
+        with:
+          repo-token: ${{ steps.mint-github-token.outputs.token }}
+          operations-per-run: 300 # Increased burndown limit for first execution
 
-        # Issue configuration (60 days total: 53 inactive + 7 warning)
-        days-before-issue-stale: 53
-        days-before-issue-close: 7
-        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'
-        stale-issue-label: 'stale'
+          # Issue configuration (60 days total: 53 inactive + 7 warning)
+          days-before-issue-stale: 53
+          days-before-issue-close: 7
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'
+          stale-issue-label: 'stale'
 
-        # PR configuration (30 days total: 23 inactive + 7 warning)
-        days-before-pr-stale: 23
-        days-before-pr-close: 7
-        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. Please leave a comment to remove this status.'
-        stale-pr-label: 'stale'
+          # PR configuration (30 days total: 23 inactive + 7 warning)
+          days-before-pr-stale: 23
+          days-before-pr-close: 7
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. Please leave a comment to remove this status.'
+          stale-pr-label: 'stale'

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -81,7 +81,7 @@ jobs:
           }
 
     - name: 'Run official stale bot'
-      uses: actions/stale@v9
+      uses: actions/stale@v10.2.0
       env:
         GITHUB_REPOSITORY: 'google-github-actions/${{ matrix.repo }}'
       with:

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -43,8 +43,8 @@ jobs:
           GH_TOKEN: '${{ steps.mint-github-token.outputs.token }}'
         run: |
           # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
-          REPOS=$(gh api --paginate /orgs/google-github-actions/repos -q '[.[] | select(.archived == false and .private == false and .fork == false) | .name]' | jq -c .)
-          echo "repos=${REPOS}" >> "$GITHUB_OUTPUT"
+REPOS=$(gh api --paginate /orgs/google-github-actions/repos | jq -s 'add | [.[] | select(.archived == false and .private == false and .fork == false) | .name]' -c)
+echo "repos=${REPOS}" >> "$GITHUB_OUTPUT"
 
   # Stage 2: Fan out official actions/stale across all discovered repositories
   apply-stale-rules:

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
           REPOS=$(gh api --paginate /orgs/google-github-actions/repos -q '[.[] | select(.archived == false and .private == false and .fork == false) | .name]' | jq -c .)
-          echo "repos=${REPOS}" >> $GITHUB_OUTPUT
+          echo "repos=${REPOS}" >> "$GITHUB_OUTPUT"
 
   # Stage 2: Fan out official actions/stale across all discovered repositories
   apply-stale-rules:

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   # Stage 1: Query the organization for all active repositories
   fetch-repositories:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.repos }}
+      matrix: '${{ steps.set-matrix.outputs.repos }}'
     steps:
       - id: 'auth-minty'
         name: 'Authenticate to Google Cloud'
@@ -40,7 +40,7 @@ jobs:
       - name: 'List active repositories'
         id: set-matrix
         env:
-          GH_TOKEN: ${{ steps.mint-github-token.outputs.token }}
+          GH_TOKEN: '${{ steps.mint-github-token.outputs.token }}'
         run: |
           # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
           REPOS=$(gh api --paginate /orgs/google-github-actions/repos -q '[.[] | select(.archived == false and .private == false and .fork == false) | .name]' | jq -c .)
@@ -49,11 +49,11 @@ jobs:
   # Stage 2: Fan out official actions/stale across all discovered repositories
   apply-stale-rules:
     needs: fetch-repositories
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        repo: ${{ fromJson(needs.fetch-repositories.outputs.matrix) }}
+        repo: '${{ fromJson(needs.fetch-repositories.outputs.matrix) }}'
 
     steps:
       - id: 'auth-minty'
@@ -81,11 +81,11 @@ jobs:
             }
 
       - name: 'Run official stale bot'
-        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # ratchet:actions/stale@v10.2.0
+        uses: 'actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f' # ratchet:actions/stale@v10.2.0
         env:
           GITHUB_REPOSITORY: 'google-github-actions/${{ matrix.repo }}'
         with:
-          repo-token: ${{ steps.mint-github-token.outputs.token }}
+          repo-token: '${{ steps.mint-github-token.outputs.token }}'
           operations-per-run: 300 # Increased burndown limit for first execution
 
           # Issue configuration (60 days total: 53 inactive + 7 warning)

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -43,8 +43,8 @@ jobs:
           GH_TOKEN: '${{ steps.mint-github-token.outputs.token }}'
         run: |
           # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
-REPOS=$(gh api --paginate /orgs/google-github-actions/repos | jq -s 'add | [.[] | select(.archived == false and .private == false and .fork == false) | .name]' -c)
-echo "repos=${REPOS}" >> "$GITHUB_OUTPUT"
+          REPOS=$(gh api --paginate /orgs/google-github-actions/repos | jq -s 'add | [.[] | select(.archived == false and .private == false and .fork == false) | .name]' -c)
+          echo "repos=${REPOS}" >> "$GITHUB_OUTPUT"
 
   # Stage 2: Fan out official actions/stale across all discovered repositories
   apply-stale-rules:

--- a/.github/workflows/centralized-stale.yml
+++ b/.github/workflows/centralized-stale.yml
@@ -1,0 +1,101 @@
+name: 'Centralized Organization Stale Bot'
+
+on:
+  schedule:
+  # Run daily at 01:00 UTC
+  - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  # Stage 1: Query the organization for all active repositories
+  fetch-repositories:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.repos }}
+    steps:
+    - id: 'auth-minty'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+      with:
+        create_credentials_file: false
+        export_environment_variables: false
+        workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+        service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+        token_format: 'id_token'
+        id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+        id_token_include_email: true
+
+    - id: 'mint-github-token'
+      uses: 'abcxyz/github-token-minter/.github/actions/minty@45c29ca3418ff3bb3ad5815d88a80536efeba21b' # ratchet:abcxyz/github-token-minter/.github/actions/minty@main
+      with:
+        id_token: '${{ steps.auth-minty.outputs.id_token }}'
+        service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+        requested_permissions: |-
+          {
+            "scope": "stale-bot",
+            "repositories": ["*"],
+            "org_name": "google-github-actions"
+          }
+
+    - name: 'List active repositories'
+      id: set-matrix
+      env:
+        GH_TOKEN: ${{ steps.mint-github-token.outputs.token }}
+      run: |
+        # Query GitHub API for active, public, non-forked repositories and force single-line JSON to prevent GITHUB_OUTPUT truncation
+        REPOS=$(gh api --paginate /orgs/google-github-actions/repos -q '[.[] | select(.archived == false and .private == false and .fork == false) | .name]' | jq -c .)
+        echo "repos=${REPOS}" >> $GITHUB_OUTPUT
+
+  # Stage 2: Fan out official actions/stale across all discovered repositories
+  apply-stale-rules:
+    needs: fetch-repositories
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJson(needs.fetch-repositories.outputs.matrix) }}
+
+    steps:
+    - id: 'auth-minty'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # ratchet:google-github-actions/auth@v2
+      with:
+        create_credentials_file: false
+        export_environment_variables: false
+        workload_identity_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+        service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+        token_format: 'id_token'
+        id_token_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+        id_token_include_email: true
+
+    - id: 'mint-github-token'
+      uses: 'abcxyz/github-token-minter/.github/actions/minty@45c29ca3418ff3bb3ad5815d88a80536efeba21b' # ratchet:abcxyz/github-token-minter/.github/actions/minty@main
+      with:
+        id_token: '${{ steps.auth-minty.outputs.id_token }}'
+        service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
+        requested_permissions: |-
+          {
+            "scope": "stale-bot",
+            "repositories": ["${{ matrix.repo }}"],
+            "org_name": "google-github-actions"
+          }
+
+    - name: 'Run official stale bot'
+      uses: actions/stale@v9
+      env:
+        GITHUB_REPOSITORY: 'google-github-actions/${{ matrix.repo }}'
+      with:
+        repo-token: ${{ steps.mint-github-token.outputs.token }}
+        operations-per-run: 300 # Increased burndown limit for first execution
+
+        # Issue configuration (60 days total: 53 inactive + 7 warning)
+        days-before-issue-stale: 53
+        days-before-issue-close: 7
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'
+        stale-issue-label: 'stale'
+
+        # PR configuration (30 days total: 23 inactive + 7 warning)
+        days-before-pr-stale: 23
+        days-before-pr-close: 7
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. Please leave a comment to remove this status.'
+        stale-pr-label: 'stale'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,9 +11,12 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
       with:
+        # Checkout the base repository ref, not the PR's head commit
+        ref: ${{ github.event.pull_request.base.sha }}
         persist-credentials: false
     - name: 'Run Scorecard'
       uses: ossf/scorecard-action@v2.4.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Checkout the base repository ref, not the PR's head commit
         ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,28 +3,29 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
-  id-token: write
+permissions: read-all
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-        with:
-          # Checkout the base repository ref, not the PR's head commit
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-      - name: 'Run Scorecard'
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # ratchet:ossf/scorecard-action@v2.4.3
-        with:
-          results_file: 'results.sarif'
-          results_format: 'sarif'
-          publish_results: false
-      - name: 'Upload to GitHub Security Tab'
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # ratchet:github/codeql-action/upload-sarif@v4.35.1
-        with:
-          sarif_file: 'results.sarif'
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      with:
+        # Checkout the base repository ref, not the PR's head commit
+        ref: ${{ github.event.pull_request.base.sha }}
+        persist-credentials: false
+    - name: 'Run Scorecard'
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # ratchet:ossf/scorecard-action@v2.4.3
+      with:
+        results_file: 'results.sarif'
+        results_format: 'sarif'
+        publish_results: false
+    - name: 'Upload to GitHub Security Tab'
+      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # ratchet:github/codeql-action/upload-sarif@v4.35.1
+      with:
+        sarif_file: 'results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,29 +3,29 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: read-all
+permissions: 'read-all'
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
-      security-events: write
-      id-token: write
+      contents: 'read'
+      security-events: 'write'
+      id-token: 'write'
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+    - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # ratchet:actions/checkout@v6
       with:
         # Checkout the base repository ref, not the PR's head commit
-        ref: ${{ github.event.pull_request.base.sha }}
+        ref: '${{ github.event.pull_request.base.sha }}'
         persist-credentials: false
     - name: 'Run Scorecard'
-      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # ratchet:ossf/scorecard-action@v2.4.3
+      uses: 'ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a' # ratchet:ossf/scorecard-action@v2.4.3
       with:
         results_file: 'results.sarif'
         results_format: 'sarif'
         publish_results: false
     - name: 'Upload to GitHub Security Tab'
-      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # ratchet:github/codeql-action/upload-sarif@v4.35.1
+      uses: 'github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13' # ratchet:github/codeql-action/upload-sarif@v4.35.1
       with:
         sarif_file: 'results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,27 @@
+name: 'Scorecard'
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: 'Run Scorecard'
+      uses: ossf/scorecard-action@v2.4.3
+      with:
+        results_file: 'results.sarif'
+        results_format: 'sarif'
+        publish_results: false
+    - name: 'Upload to GitHub Security Tab'
+      uses: github/codeql-action/upload-sarif@v4.35.1
+      with:
+        sarif_file: 'results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
     - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # ratchet:actions/checkout@v6
       with:
-        # Checkout the base repository ref, not the PR's head commit
-        ref: '${{ github.event.pull_request.base.sha }}'
         persist-credentials: false
     - name: 'Run Scorecard'
       uses: 'ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a' # ratchet:ossf/scorecard-action@v2.4.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v6
-      with:
-        # Checkout the base repository ref, not the PR's head commit
-        ref: ${{ github.event.pull_request.base.sha }}
-        persist-credentials: false
-    - name: 'Run Scorecard'
-      uses: ossf/scorecard-action@v2.4.3
-      with:
-        results_file: 'results.sarif'
-        results_format: 'sarif'
-        publish_results: false
-    - name: 'Upload to GitHub Security Tab'
-      uses: github/codeql-action/upload-sarif@v4.35.1
-      with:
-        sarif_file: 'results.sarif'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          # Checkout the base repository ref, not the PR's head commit
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - name: 'Run Scorecard'
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # ratchet:ossf/scorecard-action@v2.4.3
+        with:
+          results_file: 'results.sarif'
+          results_format: 'sarif'
+          publish_results: false
+      - name: 'Upload to GitHub Security Tab'
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # ratchet:github/codeql-action/upload-sarif@v4.35.1
+        with:
+          sarif_file: 'results.sarif'

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
- Deploy a centralized multi-repository stale bot utilizing GitHub's official `actions/stale` within a dynamic matrix workflow.
 
- To prevent individual repositories from bypassing security standards, enforce
Actionlint and Scorecard centrally using a GitHub Organization Ruleset.

